### PR TITLE
Implement OpenHear-inspired repo hygiene and CI improvements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,21 @@
+---
+# Baseline clang-format style for OpenEarable firmware sources.
+# Applied to files under src/ by the pre-commit hook in
+# .pre-commit-config.yaml. Chosen to be close to the existing Arduino /
+# K&R-flavoured style already used in the codebase rather than imposing a
+# new one.
+BasedOnStyle: Google
+Language: Cpp
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 100
+AccessModifierOffset: -4
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BreakBeforeBraces: Attach
+DerivePointerAlignment: false
+PointerAlignment: Left
+SortIncludes: false
+SpacesBeforeTrailingComments: 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+[*.{c,cpp,h,hpp,ino}]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -1,0 +1,24 @@
+name: Arduino Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: arduino-lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run arduino-lint
+        uses: arduino/arduino-lint-action@v1
+        with:
+          library-manager: update
+          compliance: specification
+          project-type: library

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,43 @@
+name: Compile examples
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  compile:
+    name: Compile (${{ matrix.board.name }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        board:
+          - name: Arduino Nano 33 BLE Sense (mbed_nano)
+            fqbn: arduino:mbed_nano:nano33ble
+            platforms: |
+              - name: arduino:mbed_nano
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compile example sketches
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
+          sketch-paths: |
+            - examples
+          libraries: |
+            - source-path: ./
+            - name: ArduinoBLE
+            - name: Adafruit BMP280 Library
+            - name: DFRobot_BMX160
+            - name: Arduino_LPS22HB
+            - name: STM32duino LSM6DSR
+          enable-deltas-report: true
+          verbose: false

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,26 @@ src/main.cpp
 
 # VS Code
 **/.vscode
+
+# JetBrains IDEs
+**/.idea
+
+# Arduino / Arduino CLI build output
+build/
+**/build/
+*.hex
+*.bin
+*.elf
+*.map
+
+# PlatformIO
+.pio/
+.pioenvs/
+.piolibdeps/
+.clang_complete
+.gcc-flags.json
+
+# Python tooling sometimes used in helper scripts
+__pycache__/
+*.pyc
+.venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '\.md$'
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.8
+    hooks:
+      - id: clang-format
+        files: '^src/.*\.(c|cc|cpp|h|hpp|ino)$'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to this firmware are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This is a fork of the upstream
+[OpenEarable/open-earable](https://github.com/OpenEarable/open-earable)
+firmware. Entries below summarise the upstream history that this fork is
+based on; please refer to upstream tags for authoritative release notes.
+
+## [Unreleased]
+
+### Added
+- Repository hygiene and contributor docs: `.editorconfig`,
+  `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`, `COPILOT.md`.
+- Continuous integration: `arduino/compile-sketches` workflow that builds
+  the example sketches for the `mbed_nano` and `nrf52` board architectures
+  declared in `library.properties`.
+- `arduino-lint` workflow to validate Arduino library structure on every
+  push and pull request.
+- `clang-format` configuration and a `pre-commit` hook that applies it to
+  sources under `src/`.
+- `HARDWARE.md` documenting hardware revisions 1.3.0 and 1.4.0 and pointing
+  to related downstream projects.
+
+### Changed
+- Extended `.gitignore` to cover Arduino CLI build output, PlatformIO
+  artefacts, and common IDE folders.
+
+### Notes
+- License (`LICENSE`) is intentionally left untouched. This repository
+  remains under the upstream OpenEarable license; downstream additions in
+  this fork are contributed under the same terms.
+
+## [1.4.0] — Unreleased upstream work
+
+Tracks the upstream `v1.4.0` line described in `README.md`.
+
+### Added
+- Support for hardware revision 1.4.0, which adds dual ultrasound
+  microphones: one in-ear and one out-of-ear.
+
+### Changed
+- When both microphones are enabled the maximum sampling rate of 62.5 kHz
+  cannot be achieved because of bandwidth constraints. See the README for
+  details.
+
+## [1.3.0] — Upstream baseline
+
+This is the upstream release that the fork is currently aligned with, as
+reflected by `library.properties` (`version=1.3.0`).
+
+### Included
+- BLE API exposing the IMU, pressure sensor, microphone, RGB LED, and audio
+  player.
+- Notifications for button state and battery level changes.
+- Compatibility with the OpenEarable dashboard and edge-ml.org.
+- Support for hardware revision 1.3.0 (9-axis IMU, pressure sensor,
+  speaker, in-ear ultrasound microphone).
+
+[Unreleased]: https://github.com/ljbudgie/open-earable/compare/v1.3.0...HEAD
+[1.4.0]: https://github.com/OpenEarable/open-earable/releases/tag/v1.4.0
+[1.3.0]: https://github.com/OpenEarable/open-earable/releases/tag/v1.3.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+OpenEarable is a research platform for ear-based sensing. That research touches
+people's bodies and senses, so this community holds itself to a high bar:
+every contributor — deaf, hard of hearing, hearing, neurodivergent, and
+otherwise — has an equal right to be heard.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and lived experiences,
+  including different experiences of hearing and deafness.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologising to those affected by our mistakes,
+  and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall
+  community and for end users who depend on this software.
+
+Examples of unacceptable behaviour include:
+
+- The use of sexualised language or imagery, and sexual attention or advances
+  of any kind.
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks.
+- Public or private harassment.
+- Ableist language or jokes about deafness, hearing loss, hearing aids,
+  cochlear implants, or related disabilities.
+- Publishing others' private information, such as a physical or email address,
+  raw sensor recordings, or biometric data, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behaviour and will take appropriate and fair corrective action in
+response to any behaviour that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned with this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported privately to the project maintainers via a GitHub Security Advisory
+at <https://github.com/ljbudgie/open-earable/security/advisories/new> (use the
+"Report a vulnerability" workflow as a private channel) or by contacting
+[@ljbudgie](https://github.com/ljbudgie) directly. All complaints will be
+reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behaviour deemed
+unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behaviour was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact:** A violation through a single incident or series of
+actions.
+
+**Consequence:** A warning with consequences for continued behaviour. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time.
+
+### 3. Temporary Ban
+
+**Community Impact:** A serious violation of community standards, including
+sustained inappropriate behaviour.
+
+**Consequence:** A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time.
+
+### 4. Permanent Ban
+
+**Community Impact:** Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behaviour, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct
+enforcement ladder.
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/COPILOT.md
+++ b/COPILOT.md
@@ -1,0 +1,45 @@
+You are working on OpenEarable: open-source Arduino firmware for an
+ear-worn research platform with BLE connectivity, a 9-axis IMU, a pressure
+sensor, one or two ultrasound microphones, a speaker, an RGB LED, a push
+button, and an SD card.
+
+Core rules:
+
+- This repository is a fork of `OpenEarable/open-earable`. Do **not** modify
+  `LICENSE` or add license addenda — the upstream copyright holders set the
+  terms. Contribute changes under the existing license.
+- Keep changes minimal and surgical. The firmware ships to physical hardware
+  and is consumed by the Arduino Library Manager; structural churn breaks
+  downstream users.
+- Preserve compatibility with both supported hardware revisions, 1.3.0 and
+  1.4.0, unless a change is explicitly hardware-gated.
+- Treat audio output as safety-critical. Do not introduce code paths that
+  can drive the speaker to unsafe sound pressure levels. Default-safe
+  configurations only.
+- Keep all sensor processing on-device. Do not add network/cloud
+  dependencies to the firmware.
+- Match the existing C++ / Arduino style. Run `clang-format` (see
+  `.clang-format`) on files you touch under `src/`.
+- Keep `library.properties` valid:
+  - Bump `version=` for releases following SemVer.
+  - Keep `architectures=` in sync with the boards actually supported.
+  - Keep `depends=` accurate; do not add libraries that are not actually
+    `#include`d.
+- When you add or change a BLE service or characteristic, update the
+  "BLE Specification" section in `README.md` so dashboard and edge-ml
+  consumers stay in sync.
+- When you add a new example, place it under `examples/<Name>/<Name>.ino`
+  so the `arduino/compile-sketches` workflow picks it up automatically.
+
+Tooling:
+
+- Recommended build path: the
+  [open-earable-PlatformIO wrapper](https://github.com/OpenEarable/open-earable-PlatformIO).
+- CI builds examples with `arduino/compile-sketches` for the `mbed_nano`
+  and `nrf52` architectures and runs `arduino-lint` against the library
+  metadata.
+- Local style: `pre-commit run --all-files` applies whitespace fixes and
+  `clang-format` to `src/`.
+
+When unsure, prefer changes that improve documentation, tests, or CI over
+changes that alter firmware behaviour.

--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -1,0 +1,70 @@
+# Hardware
+
+This firmware targets the OpenEarable ear-worn research platform. The
+canonical hardware project and PCB sources live in the upstream
+[OpenEarable](https://github.com/OpenEarable) organisation; this document
+only summarises what the firmware in this repository expects, and points
+to related downstream projects that build on top of OpenEarable hardware.
+
+## Supported revisions
+
+| Revision | Sensors / actuators                                                                                  |
+| -------- | ---------------------------------------------------------------------------------------------------- |
+| `1.3.0`  | 9-axis IMU, ear-canal pressure & temperature sensor, in-ear ultrasound microphone, speaker, RGB LED, push button, microSD slot |
+| `1.4.0`  | All of `1.3.0`, plus a second (out-of-ear) ultrasound microphone for dual-microphone capture          |
+
+When both microphones on a `1.4.0` device are enabled simultaneously the
+maximum per-channel sample rate of 62.5 kHz cannot be reached due to
+bandwidth constraints — see the BLE specification in
+[`README.md`](README.md) for the current limits.
+
+## Storage
+
+OpenEarable records audio to, and plays audio from, an on-board microSD
+card. The firmware expects:
+
+- A SanDisk Extreme Class 3 (or equivalent class 10 / A30) card, and
+- The card formatted as **exFAT**.
+
+Other classes are not supported and will produce audio dropouts.
+
+## Build & flashing
+
+The recommended way to build and flash the firmware is the
+[open-earable-PlatformIO](https://github.com/OpenEarable/open-earable-PlatformIO)
+wrapper, which pins the toolchain, libraries, and bootloader for you.
+Building inside the Arduino IDE is also supported; the per-library setup
+steps for `SdFat`, `Adafruit_BMP280`, the SPI/Wire configuration, and the
+Nano 33 BLE Sense board variant are documented in detail in
+[`README.md`](README.md).
+
+## Related downstream projects
+
+Other open projects consume OpenEarable hardware or are designed to be
+worn alongside it. Notes here are informational; this repository does not
+depend on them.
+
+### OpenHear
+
+[OpenHear](https://github.com/ljbudgie/openhear) is an independent,
+sovereign-audio DSP and haptic-wristband project written in Python. It
+treats the OpenEarable as one possible source of in-ear audio and IMU
+signals for its pipeline. Useful entry points if you are combining the
+two projects:
+
+- **Clinician guide** —
+  [`CLINICIAN_GUIDE.md`](https://github.com/ljbudgie/openhear/blob/main/CLINICIAN_GUIDE.md)
+  documents sovereignty-first fitting workflows (audiograms, fitting
+  receipts, no raw-audio leakage).
+- **Wristband build guide** —
+  [`HARDWARE.md`](https://github.com/ljbudgie/openhear/blob/main/HARDWARE.md)
+  in the OpenHear repository describes the no-solder haptic wristband
+  prototype that pairs with OpenEarable-style in-ear sensing.
+- **Sovereign audio architecture** —
+  [`SOVEREIGN_AUDIO.md`](https://github.com/ljbudgie/openhear/blob/main/SOVEREIGN_AUDIO.md)
+  explains the data-handling model OpenHear applies on top of any
+  hardware capture source.
+
+The licensing and project goals of OpenHear and OpenEarable differ;
+please read each project's `LICENSE` and `README.md` before combining
+them in a deployment.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ For more information visit the [OpenEarable](https://open-earable.teco.edu/) web
 
 OpenEarable is controlled and streams sensor data via BLE (Bluetooth Low Energy). Audio is played from and recorded to the internal SD card (required card SanDisk Extreme Class 3, must be formatted as exFAT). OpenEarable is compatible with the provided [dashboard](https://github.com/OpenEarable/dashboard) and [edge-ml](https://edge-ml.org/). 
 
+> **Downstream projects:** [OpenHear](https://github.com/ljbudgie/openhear) is an independent, sovereign-audio DSP and haptic-wristband project (Python) that can treat OpenEarable as one possible in-ear sensing source. It is not required to use OpenEarable and is licensed separately — see [`HARDWARE.md`](HARDWARE.md) for cross-references.
+
 
 ## Setup
 **⚠️ $${\rm\color{red}Please~Note:}$$ We recommend deploying the firmware using the  [open-earable-PlatformIO wrapper](https://github.com/OpenEarable/open-earable-PlatformIO).**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,89 @@
+# Security Policy
+
+This repository contains firmware for the OpenEarable hardware platform —
+an Arduino-based earable with BLE connectivity, an IMU, a pressure sensor,
+microphones, a speaker, and an RGB LED. Security and safety bugs in this
+firmware can have real physical consequences (for example excessive sound
+pressure produced by the on-board speaker, loss of BLE pairing controls, or
+leaking of sensor data over the air). We take both classes of issue
+seriously.
+
+## Supported versions
+
+This fork tracks the upstream OpenEarable firmware. Only the latest commit on
+the `main` branch and the most recent tagged release receive security fixes.
+There is no LTS branch.
+
+| Version          | Supported |
+| ---------------- | --------- |
+| `main`           | ✅        |
+| Latest release   | ✅        |
+| Older releases   | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security problems.**
+
+Use one of the following private channels instead:
+
+1. **Preferred:** open a private vulnerability report through GitHub Security
+   Advisories —
+   <https://github.com/ljbudgie/open-earable/security/advisories/new>.
+2. If you cannot use GitHub Security Advisories, contact the maintainer via
+   their GitHub profile (<https://github.com/ljbudgie>) and request a private
+   disclosure channel before sharing any details.
+
+For issues that originate in the upstream OpenEarable codebase, please also
+consider reporting them to the upstream project at
+<https://github.com/OpenEarable/open-earable>.
+
+When reporting, please include:
+
+- A clear description of the issue and its impact (firmware vulnerability,
+  hearing- or hardware-safety issue, BLE pairing or data-handling issue,
+  supply-chain issue, etc.).
+- Steps to reproduce, including:
+  - Hardware revision (1.3.0 or 1.4.0).
+  - Arduino IDE / PlatformIO version and toolchain.
+  - Library versions listed in `library.properties`.
+  - Any companion software (e.g. the OpenEarable dashboard, edge-ml).
+- The commit SHA or release tag the report applies to.
+- Any proposed mitigation, if you have one.
+
+## What to expect
+
+- We aim to acknowledge new reports within **5 working days**.
+- We aim to provide a remediation plan or assessment within **30 days**.
+- Coordinated disclosure is preferred. We will agree a disclosure date with
+  the reporter and credit reporters who wish to be named.
+
+## Scope
+
+In scope:
+
+- All firmware sources in `src/` (BLE services, sensor drivers, audio
+  pipeline, SD logger, task manager, LED/button handling).
+- Example sketches in `examples/`.
+- Build resources in `resources/` that ship with the library
+  (bootloaders, board variants, precompiled blobs, SPI/Wire config).
+- `library.properties` and CI configuration that could be abused to ship
+  altered firmware.
+
+Out of scope:
+
+- Vulnerabilities in third-party libraries listed under `depends=` in
+  `library.properties`. Please report those upstream to the corresponding
+  project.
+- Vulnerabilities in the Arduino IDE, Arduino CLI, PlatformIO, or board
+  packages themselves.
+- Theoretical issues without a credible attack path against an OpenEarable
+  device.
+
+## Hearing-safety reports
+
+OpenEarable is **not** a medical device. If you believe a configuration,
+default, or code path in this firmware can produce sound pressure levels
+through the on-board speaker that risk hearing damage, please report it
+through the same private channel above and flag it as a **safety** issue.
+We treat hearing-safety bugs with the same priority as security
+vulnerabilities.


### PR DESCRIPTION
This pull request introduces several improvements focused on repository hygiene, contributor documentation, and continuous integration for the OpenEarable firmware project. It adds essential configuration files for code formatting, pre-commit hooks, and CI workflows, as well as comprehensive documentation covering contribution guidelines, security policy, hardware details, and changelogs. These changes aim to standardize development practices, improve code quality, and make it easier for new contributors to get involved.

**Repository hygiene and contributor documentation:**

* Added `.editorconfig` and `.clang-format` to enforce consistent code style and formatting across the codebase. (`.editorconfig`, `.clang-format`) [[1]](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR1-R21) [[2]](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2R1-R21)
* Introduced `CODE_OF_CONDUCT.md`, `SECURITY.md`, `COPILOT.md`, and `CHANGELOG.md` to clarify contribution rules, security reporting, project conduct, and changelog practices. (`CODE_OF_CONDUCT.md`, `SECURITY.md`, `COPILOT.md`, `CHANGELOG.md`) [[1]](diffhunk://#diff-ffdbe3a1e7ee93cacfc080b6c635ccf3a8f6b0f00f2fb884f78c6b5f9dac8fd2R1-R133) [[2]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7R1-R89) [[3]](diffhunk://#diff-c1c8a0dbd9e9ae4cfc22cdf35c043c4b8d6f4620359a21cc1a056de2ac398f50R1-R45) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R65)
* Added `HARDWARE.md` to document supported hardware revisions and related downstream projects, and updated `README.md` to reference downstream projects. (`HARDWARE.md`, `README.md`) [[1]](diffhunk://#diff-59e50a4c6ff2a11047e2935a1c205a13a545b754302987bf3b401c6571ead38aR1-R70) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49-R50)

**Continuous integration and code quality:**

* Added GitHub Actions workflows: `arduino-lint.yml` to validate Arduino library structure and `compile-examples.yml` to build example sketches for supported board architectures on every push and pull request. (`.github/workflows/arduino-lint.yml`, `.github/workflows/compile-examples.yml`) [[1]](diffhunk://#diff-cace231037e00a38748cbe5f9bb7df9460adf1063007e2905db98e6309f2d6c0R1-R24) [[2]](diffhunk://#diff-5e8968a2eeba10018e702f1a34161eef3e89f76406123286100b969fffdc416fR1-R43)
* Introduced `.pre-commit-config.yaml` to enable pre-commit hooks for whitespace, YAML, and C++ formatting checks using `clang-format`. (`.pre-commit-config.yaml`)